### PR TITLE
Feat: 수신부

### DIFF
--- a/prisma/migrations/20240802125528_add_unique_to_channel_id/migration.sql
+++ b/prisma/migrations/20240802125528_add_unique_to_channel_id/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[channelId]` on the table `ReceiveChannel` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[channelId]` on the table `SendChannel` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `ReceiveChannel_channelId_key` ON `ReceiveChannel`(`channelId`);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `SendChannel_channelId_key` ON `SendChannel`(`channelId`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model Server {
 
 model SendChannel {
   id              Int          @id @default(autoincrement())
-  channelId       String
+  channelId       String       @unique
   serverId        String
   
   receiveChannels SendToReceive[]
@@ -26,7 +26,7 @@ model SendChannel {
 
 model ReceiveChannel {
   id            Int            @id @default(autoincrement())
-  channelId     String
+  channelId     String         @unique
   serverId      String
 
   sendChannels  SendToReceive[]

--- a/src/commands/receive/delete.ts
+++ b/src/commands/receive/delete.ts
@@ -9,6 +9,13 @@ import { Discord, Slash, SlashGroup, SlashOption } from "discordx";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import prisma from "@/utilities/prisma";
 
+/**
+ * Returns the all of this server's receiver channel list
+ * 
+ * @param interaction 
+ * @param query - Channel name to find. Default is ""
+ * @returns Array of receiver channels
+ */
 async function getReceiveChannels(interaction: Interaction, query: string = "") {
   if (!interaction.guild) return [];
 
@@ -31,6 +38,12 @@ async function getReceiveChannels(interaction: Interaction, query: string = "") 
     .filter((channel) => channel.name.includes(query));
 }
 
+/**
+ * Returns the all receiver channel list by option form
+ * 
+ * @param interaction 
+ * @returns Array of receiver channels by option form
+ */
 async function getOptions(interaction: AutocompleteInteraction) {
   if (!interaction.guild) return;
 

--- a/src/commands/receive/delete.ts
+++ b/src/commands/receive/delete.ts
@@ -1,0 +1,92 @@
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Interaction,
+  TextChannel,
+} from "discord.js";
+import { Discord, Slash, SlashGroup, SlashOption } from "discordx";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import prisma from "@/utilities/prisma";
+
+async function getReceiveChannels(interaction: Interaction, query: string = "") {
+  if (!interaction.guild) return [];
+
+  const allChannels = Array.from(await interaction.guild.channels.fetch())
+    .map(([, channel]) => channel)
+    .filter((channel) => channel instanceof TextChannel);
+
+  const registeredChannelIds = (
+    await prisma.receiveChannel.findMany({
+      where: { serverId: interaction.guildId! },
+    })
+  ).map((channel) => channel.channelId);
+
+  return allChannels
+    .filter((channel) =>
+      registeredChannelIds.some(
+        (registeredChannelId) => registeredChannelId === channel.id
+      )
+    )
+    .filter((channel) => channel.name.includes(query));
+}
+
+async function getOptions(interaction: AutocompleteInteraction) {
+  if (!interaction.guild) return;
+
+  const input = interaction.options.getString("channel") || "";
+
+  return interaction.respond(
+    (await getReceiveChannels(interaction, input))
+      .map((channel) => ({
+        name: `# ${channel.name}`,
+        value: channel.id,
+      }))
+      .slice(0, 25)
+  );
+}
+
+@Discord()
+@SlashGroup("receiver")
+export class Receiver {
+  @Slash({ name: "delete", description: "delete a receiver channel" })
+  async delete(
+    @SlashOption({
+      name: "channel",
+      description: "the channel to delete as a receiver",
+      required: true,
+      type: ApplicationCommandOptionType.String,
+      autocomplete: getOptions,
+    })
+    channel: string,
+    interaction: ChatInputCommandInteraction
+  ) {
+    if (!interaction.guildId) {
+      return await interaction.reply("failed: guild not found");
+    }
+
+    const channels = await getReceiveChannels(interaction, "");
+    if (channels.findIndex((c) => c.id === channel) === -1) {
+      return await interaction.reply("failed: channel not found");
+    }
+
+    try {
+      await prisma.receiveChannel.deleteMany({
+        where: {
+          serverId: interaction.guildId!,
+          channelId: channel,
+        },
+      });
+      await interaction.reply(`deleted receiver channel <#${channel}>`);
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        if (error.code === "P2025") {
+          return await interaction.reply("failed: channel not found");
+        }
+      } else {
+        console.error(error);
+        return await interaction.reply("failed: unknown error");
+      }
+    }
+  }
+}

--- a/src/commands/receive/list.ts
+++ b/src/commands/receive/list.ts
@@ -1,0 +1,71 @@
+import prisma from "@/utilities/prisma";
+import { ChatInputCommandInteraction, TextChannel } from "discord.js";
+import { Discord, Slash, SlashGroup } from "discordx";
+
+@Discord()
+@SlashGroup("receiver")
+export class Recevier {
+  @Slash({ name: "list", description: "list a receiver channel" })
+  async list(interaction: ChatInputCommandInteraction) {
+    if (!interaction.guildId) return;
+
+    // 디스코드 서버에 등록된 모든 채널 조회
+    const allChannels = Array.from(
+      await interaction.guild!.channels.fetch()
+    ).map(([, channel]) => channel);
+
+    // DB에 등록된 채널 조회
+    const registeredChannels = await prisma.receiveChannel.findMany({
+      where: { serverId: interaction.guildId },
+      select: {
+        channelId: true,
+        sendChannels: {
+          select: {
+            sendChannelId: true,
+          },
+        },
+      },
+    });
+
+    // 두 데이터를 합하여 필요한 데이터만 추출
+    const channels = registeredChannels.reduce(
+      (acc, receiveChannel) => {
+        const channel = allChannels.find(
+          (c) => c?.id === receiveChannel.channelId
+        );
+
+        if (channel instanceof TextChannel) {
+          acc.push({
+            id: channel.id,
+            count: receiveChannel.sendChannels.length,
+          });
+        }
+
+        return acc;
+      },
+      [] as { id: string; count: number }[]
+    );
+
+    // 빈 임베드를 보내지 않기 위함
+    if (channels.length === 0) {
+      await interaction.reply("No receiver channels found in this server");
+      return;
+    }
+
+    await interaction.reply({
+      embeds: [
+        {
+          author: {
+            name: interaction.guild!.name,
+            icon_url: interaction.guild!.iconURL() || undefined,
+          },
+          title: "Receiver Channels",
+          fields: channels.map((channel) => ({
+            name: "",
+            value: `<#${channel.id}> ・ is listening to ${channel.count} sender channels`,
+          })),
+        },
+      ],
+    });
+  }
+}

--- a/src/commands/receive/list.ts
+++ b/src/commands/receive/list.ts
@@ -9,7 +9,7 @@ export class Recevier {
   async list(interaction: ChatInputCommandInteraction) {
     if (!interaction.guildId) return;
 
-    // 디스코드 서버에 등록된 모든 채널 조회
+    // 디스코드 서버에 등록된 모든 수신 채널 조회
     const allChannels = Array.from(
       await interaction.guild!.channels.fetch()
     ).map(([, channel]) => channel);

--- a/src/commands/receive/listen.ts
+++ b/src/commands/receive/listen.ts
@@ -186,7 +186,7 @@ export class Receiver {
           },
         });
       }
-      await interaction.reply(`added receiver channel <#${from}>`);
+      await interaction.reply(`added receiver channel <#${from}> -> <#${receiverId}>`);
     } catch (error) {
       if (error instanceof PrismaClientKnownRequestError) {
         if (error.code === "P2002") {

--- a/src/commands/receive/listen.ts
+++ b/src/commands/receive/listen.ts
@@ -1,0 +1,116 @@
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Interaction,
+  TextChannel,
+} from "discord.js";
+import { Discord, Slash, SlashGroup, SlashOption } from "discordx";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import prisma from "@/utilities/prisma";
+
+
+/**
+ * Returns the all sender channel list
+ * 
+ * @param interaction 
+ * @param query - Channel name to find. Default is ""
+ * @returns Array of channels
+ */
+async function getTextChannels(interaction: Interaction, query: string = "") {
+  if (!interaction.guild) return [];
+
+  // DB에 등록된 채널 조회
+  const registeredChannels = await prisma.sendChannel.findMany({
+    select: {
+      channelId: true,
+    },
+  });
+
+  return (await Promise.all(
+    registeredChannels.map(async (channel) => {
+      return await interaction.client.channels.fetch(channel.channelId);
+    })
+  ))
+    .filter((channel) => channel !== null)
+    .filter((channel) => channel instanceof TextChannel)
+    .filter((channel) => channel.name.includes(query))
+}
+
+async function getOptions(interaction: AutocompleteInteraction) {
+  if (!interaction.guild) return;
+
+  const input = interaction.options.getString("channel") || "";
+  const textChannels = (await getTextChannels(interaction, input)).slice(0, 25);
+
+  return interaction.respond(
+    textChannels.map((channel) => ({
+      name: `# ${channel.name}`,
+      value: channel.id,
+    }))
+  );
+}
+
+// TODO - receiver listen {channel} {to}로 변경
+@Discord()
+@SlashGroup({
+  name: "receiver",
+  description: "listen, list, and delete receiver channels",
+})
+@SlashGroup("receiver")
+export class Receiver {
+  @Slash({ name: "listen", description: "listen from sender channel" })
+  async add(
+    @SlashOption({
+      name: "channel",
+      description: "the sender channel to listen at this receiver channel",
+      required: true,
+      type: ApplicationCommandOptionType.String,
+      autocomplete: getOptions,
+    })
+    channel: string,
+    interaction: ChatInputCommandInteraction
+  ) {
+    if (!interaction.guildId) {
+      return await interaction.reply("failed: guild not found");
+    }
+
+    const textChannels = await getTextChannels(interaction, "");
+    if (textChannels.findIndex((c) => c.id === channel) === -1) {
+      return await interaction.reply("failed: channel not found");
+    }
+
+    try {
+      await prisma.receiveChannel.create({
+        data: {
+          channelId: interaction.channelId,
+          server: {
+            connectOrCreate: {
+              where: { id: interaction.guildId },
+              create: { id: interaction.guildId },
+            },
+          },
+          sendChannels: {
+            create: {
+              sendChannel: {
+                connect: { 
+                  channelId: channel
+                }
+              },
+            }
+          }
+        },
+      });
+      await interaction.reply(`added receiver channel <#${channel}>`);
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        if (error.code === "P2002") {
+          return await interaction.reply("failed: channel already exists");
+        }
+      } else {
+        console.error(error);
+        return await interaction.reply("failed: unknown error");
+      }
+    }
+  }
+}

--- a/src/commands/send/delete.ts
+++ b/src/commands/send/delete.ts
@@ -9,6 +9,13 @@ import { Discord, Slash, SlashGroup, SlashOption } from "discordx";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import prisma from "@/utilities/prisma";
 
+/**
+ * Returns the all of this server's sender channel list
+ * 
+ * @param interaction 
+ * @param query - Channel name to find. Default is ""
+ * @returns Array of sender channels
+ */
 async function getSendChannels(interaction: Interaction, query: string = "") {
   if (!interaction.guild) return [];
 
@@ -31,6 +38,12 @@ async function getSendChannels(interaction: Interaction, query: string = "") {
     .filter((channel) => channel.name.includes(query));
 }
 
+/**
+ * Returns the all sender channel list by option form
+ * 
+ * @param interaction 
+ * @returns Array of sender channels by option form
+ */
 async function getOptions(interaction: AutocompleteInteraction) {
   if (!interaction.guild) return;
 

--- a/src/events/sender.ts
+++ b/src/events/sender.ts
@@ -28,32 +28,38 @@ export class Sender {
     if (sendChannel.length === 0) return;
 
     console.log(
-      `[Sender]: ${message.guildId} 서버의 ${message.channelId} 채널의 메시지를 송신합니다.`
+      `[Sender]: ${message.guild.name}(${message.guildId}) 서버의 ${message.channelId} 채널의 메시지를 송신합니다.`
     );
 
     const receiveChannels = sendChannel[0].receiveChannels.map(
       (channel) => channel.receiveChannel
     );
-
+    
     receiveChannels.forEach(async (receiveChannel) => {
-      const channel = await client.channels.fetch(receiveChannel.channelId);
+      try {
+        const channel = await client.channels.fetch(receiveChannel.channelId);
 
-      if (channel == null) {
-        // 채널이 없으면 삭제 (채널 삭제 시 봇이 삭제 이벤트에 일일이 대응하기 힘듬)
-        await prisma.receiveChannel.deleteMany({
-          where: {
-            channelId: receiveChannel.channelId,
-            serverId: receiveChannel.serverId,
-          },
-        });
-      } else if (channel instanceof TextChannel) {
-        /* const result = */ await channel.send({
-          content: message.content,
-          files: message.attachments.map((attachment) => attachment.url),
-          embeds: message.embeds,
-          components: message.components,
-        });
+        if (channel == null) {
+          // 채널이 없으면 삭제 (채널 삭제 시 봇이 삭제 이벤트에 일일이 대응하기 힘듬)
+          await prisma.receiveChannel.deleteMany({
+            where: {
+              channelId: receiveChannel.channelId,
+              serverId: receiveChannel.serverId,
+            },
+          });
+        } else if (channel instanceof TextChannel) {
+          /* const result = */ await channel.send({
+            content: `${message.content}\n\nfrom \`${message.guild!.name}\``,
+            files: message.attachments.map((attachment) => attachment.url),
+            embeds: message.embeds,
+            components: message.components,
+          });
+        }
+      } catch(error) {
+        console.error(error);
+        console.info(`Error Info\nreceiver: ${receiveChannel}\nsender: ${message}`);
       }
+      
     });
   }
 }


### PR DESCRIPTION
# 수신부 기능
- `/receiver list`: 수신채널 리스트 불러오기
![image](https://github.com/user-attachments/assets/974d3e52-cdb8-40b2-a714-bd447f6b7351)
- `/receiver delete` `channel: channelId` 수신채널 목록에서 제거
![image](https://github.com/user-attachments/assets/d2267d41-6095-480b-b7a6-45797910d1a3)
- `/receiver listen` `from: channelId` `[to(optional): channelId]`: from 채널 -> to 채널(기본값: 명령어를 사용한 채널)
![image](https://github.com/user-attachments/assets/a0be47ce-86d4-4422-a3d1-5c08cf43fcce)

# 메세지 전송 폼을 죠큼 꾸몄습니다
![image](https://github.com/user-attachments/assets/d65df93e-5b75-4dd3-822e-0d8baa95454f)
from `서버명` <- 추가

# 예외처리
>아래와 같은 상황일 때 무한 반복 방지
>송신 -> 수신
>A -> B, B -> C, C -> A

`/sender add`와 `/receiver listen` 명령어 기능에 이미 등록된 송신 채널은 수신채널이 될 수 없도록, 또는 이미 등록된 수신채널은 송신 채널이 될 수 없도록 막았습니다.

# 주석
각 함수별로 주석을 달았습니다 (유지보수를 위함)
![image](https://github.com/user-attachments/assets/14744fac-dddc-4d1f-9eb6-9139957683b3)
